### PR TITLE
Change `next` to `text` in Item 16

### DIFF
--- a/item_16_generators_instead_of_lists.py
+++ b/item_16_generators_instead_of_lists.py
@@ -10,7 +10,7 @@ import itertools
 
 def index_words(text):
     result = []
-    if next:
+    if text:
         result.append(0)
     for index, letter in enumerate(text):
         if letter == ' ':


### PR DESCRIPTION
Updated `index_words` in Item 16 by changing changing `next` to `text`. Before this change, `index_words` would return `[0]` for an empty string.

https://github.com/SigmaQuan/Better-Python-59-Ways/blob/9eaaba2539ca0b723442f9fcdf0455c7a1fe0584/item_16_generators_instead_of_lists.py#L13

`index_words_iter` returns an empty list when `text` is an empty string which I assume is the intended result.