### PR TITLE
Correct comment annotation on to_bytes function.

### DIFF
--- a/item_03_Difference_bytes_str_unicode.py
+++ b/item_03_Difference_bytes_str_unicode.py
@@ -55,7 +55,7 @@ def to_bytes(bytes_or_str):
         value = bytes_or_str.encode('utf-8')
     else:
         value = bytes_or_str
-    return value  # Instance of str
+    return value  # Instance of bytes
 
 
 # In Python 2, you'll need one method that takes a str or unicode and always


### PR DESCRIPTION
The original comment for to_bytes function refers that it will return an instance of str, it should return an instance of bytes instead.